### PR TITLE
Modify callback function execution in sitemap.getSites.

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -30,11 +30,13 @@ sitemap.parse = function(url, callback){
 			callback(err, "Error");
 		}
 	});
-}
+};
 
 sitemap.getSites = function(url, callback){
 	var self = this;
 	var d,s,error,sites = [];
+	var sUrlSize = 1;
+	var parseCnt = 0;
 	this.parse(url, function read(err, data){
 		if(!err)
 		{
@@ -42,15 +44,20 @@ sitemap.getSites = function(url, callback){
 			{
 				sites.push(_.flatten(_.pluck(d.url, "loc")));
 				sites = _.flatten(sites);
-				callback(error,sites);
+				parseCnt++;
+				if (parseCnt === sUrlSize) {
+					callback(error, sites);
+				}
 			}
 			else if(s = data.sitemapindex)
 			{
-				_.each(_.flatten(_.pluck(s.sitemap, "loc")), function(url){
+				var sitemapUrls = _.flatten(_.pluck(s.sitemap, "loc"));
+				sUrlSize = _.size(sitemapUrls);
+				//console.log(sitemapUrls);
+				_.each(sitemapUrls, function(url){
 					self.parse(url, read);
-				})
-			}
-			else{
+				});
+			}else{
 				error = "no valid xml";
 			}
 		}else{
@@ -58,4 +65,4 @@ sitemap.getSites = function(url, callback){
 			//callback(err,sites);
 		}
 	});
-}
+};


### PR DESCRIPTION
When my site has some sitemap index urls, a callback function is executed for each sitemap index urls.
I thought it's inconvenient.
This PR is my proposal.
But I think there might be better code for same function implement.