### PR TITLE
Fixed error when site returns a non-200 status

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -26,9 +26,10 @@ sitemap.parse = function(url, callback){
 					callback(err,data);
 			});
 		}
-		else{
-			callback(err, "Error");
+		else if (!err) {
+			err = new Error('Sitemapper: Server returned a non-200 status');
 		}
+		callback(err, "Error");
 	});
 };
 


### PR DESCRIPTION
Am currently getting the following error in production:

`TypeError: Cannot read property 'urlset' of null at read (C:\Users\47\AppData\Local\Httpschecker\app-1.0.1\resources\app.asar\node_modules\sitemapper\lib\sitemap.js:43:15) at C:\Users\47\AppData\Local\Httpschecker\app-1.0.1\resources\app.asar\node_modules\sitemapper\lib\sitemap.js:26:6 at Parser.<anonymous>`

A site was returning a non-200 status code, thus failing the if statement, but as there was no error from the request, err was null and not being detected by the if statement in the parse function.