### PR TITLE
Return after callback completes to prevent multiple callback calls.

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -25,6 +25,7 @@ sitemap.parse = function(url, callback){
 			xmlParse(body, function(err,data){
 					callback(err,data);
 			});
+                        return;
 		}
 		else if (!err) {
 			err = new Error('Sitemapper: Server returned a non-200 status');


### PR DESCRIPTION
Issue: https://github.com/hawaiianchimp/sitemap-parser/issues/9